### PR TITLE
👷 add guard to prevent action build on PRs starting specific keywords

### DIFF
--- a/.github/workflows/images-pr-main.yml
+++ b/.github/workflows/images-pr-main.yml
@@ -9,6 +9,8 @@ jobs:
   build-and-push-images:
     runs-on: ubuntu-latest
 
+    if: ${{ !(contains(github.event.pull_request.title, 'SMALL') || contains(github.event.pull_request.title, 'WIP')) }}
+
     strategy:
         fail-fast: false
         matrix:


### PR DESCRIPTION
Prevents building of PRs which contain the literals 'SMALL' or 'WIP' in their title