### PR TITLE
WIP: Dynamic configurable codec by PhoneFlavor

### DIFF
--- a/app/models/crud/asterisk.py
+++ b/app/models/crud/asterisk.py
@@ -13,6 +13,7 @@ from app.models.asterisk import DialPlanEntry, PSAor, PSAuth, PSEndpoint
 from app.models.crud import CRUDNotAllowedException
 from app.models.extension import Extension
 from app.models.user import User, UserRole
+from app.telephoning.flavor import CODEC
 from app.telephoning.main import Telephoning
 
 logger = getLogger(__name__)
@@ -29,7 +30,7 @@ def create_asterisk_extension(
     extension: str,
     extension_name: str,
     password: str,
-    type: str,
+    codec: CODEC = "g722",
     context="pjsip_internal",
     autocommit=True,
 ) -> tuple[PSAor, PSAuth, PSEndpoint]:
@@ -43,13 +44,6 @@ def create_asterisk_extension(
         )
 
         # TODO: fix hard coded transport
-        flavor = Telephoning.get_flavor_by_type(type)
-        codec = (
-            flavor.SUPPORTED_CODEC
-            if isinstance(flavor.SUPPORTED_CODEC, str)
-            else flavor.SUPPORTED_CODEC[type]
-        )
-
         ps_endpoint = PSEndpoint(
             id=extension,
             transport="transport-udp",
@@ -122,9 +116,7 @@ def delete_asterisk_extension(
     if autocommit:
         session_asterisk.commit()
 
-    logger.info(
-        f"Deleted extension <{extension.extension}> in asterisk DB"
-    )
+    logger.info(f"Deleted extension <{extension.extension}> in asterisk DB")
 
 
 def create_or_update_asterisk_dialplan_entry(

--- a/app/models/crud/extension.py
+++ b/app/models/crud/extension.py
@@ -135,7 +135,7 @@ def create_extension(
                 extension=db_obj.extension,
                 extension_name=db_obj.name,
                 password=db_obj.password,
-                codec=flavor.get_codec(),
+                codec=flavor.get_codec(db_obj),
                 autocommit=False,
             )
         flavor.on_extension_create(session, session_asterisk, user, db_obj)

--- a/app/models/crud/extension.py
+++ b/app/models/crud/extension.py
@@ -135,7 +135,7 @@ def create_extension(
                 extension=db_obj.extension,
                 extension_name=db_obj.name,
                 password=db_obj.password,
-                type=db_obj.type,
+                codec=flavor.get_codec(),
                 autocommit=False,
             )
         flavor.on_extension_create(session, session_asterisk, user, db_obj)

--- a/app/telephoning/flavor.py
+++ b/app/telephoning/flavor.py
@@ -17,6 +17,8 @@ from sqlmodel import Session
 
 from app.core.config import settings
 
+CODEC = Literal["g722", "alaw", "ulaw", "g726", "gsm", "lpc10"]
+
 
 class PhoneFlavor:
     """
@@ -69,7 +71,6 @@ class PhoneFlavor:
     # in this flavor class. If it is a dict, it has to configure values for
     # all phone types from this class.
     # Supported codecs:
-    CODEC = Literal["g722", "alaw", "ulaw", "g726", "gsm", "lpc10"]
     SUPPORTED_CODEC: CODEC | dict[str, CODEC] = "g722"
 
     # If this flag is set to true, on creation of such a phone type no SIP
@@ -131,6 +132,13 @@ class PhoneFlavor:
         If itraises an NotImplementedError it will not be scheduled.
         """
         raise NotImplementedError
+
+    def get_codec(self):
+        return (
+            self.SUPPORTED_CODEC
+            if isinstance(self.SUPPORTED_CODEC, str)
+            else self.SUPPORTED_CODEC[type]
+        )
 
     ## DO NOT OVERWRITE THOSE METHODS
     def is_public(self):

--- a/app/telephoning/flavor.py
+++ b/app/telephoning/flavor.py
@@ -133,12 +133,14 @@ class PhoneFlavor:
         """
         raise NotImplementedError
 
-    def get_codec(self):
-        return (
-            self.SUPPORTED_CODEC
-            if isinstance(self.SUPPORTED_CODEC, str)
-            else self.SUPPORTED_CODEC[type]
-        )
+    def get_codec(self, extension: "Extension | None"):
+        if isinstance(self.SUPPORTED_CODEC, str):
+            return self.SUPPORTED_CODEC
+
+        if extension is None:
+            raise AttributeError("Cannot get codec for unknown phonetype")
+
+        return self.SUPPORTED_CODEC[extension.type]
 
     ## DO NOT OVERWRITE THOSE METHODS
     def is_public(self):

--- a/app/telephoning/phonetypes/mitel_dect.py
+++ b/app/telephoning/phonetypes/mitel_dect.py
@@ -129,7 +129,7 @@ class MitelDECT(PhoneFlavor):
                         extension=tmp_ext_id,
                         extension_name="DECT TMP",
                         password=password,
-                        type="DECT",
+                        codec=self.get_codec(),
                         context="pjsip_dect_tmp",
                     )
 

--- a/app/telephoning/phonetypes/mitel_dect.py
+++ b/app/telephoning/phonetypes/mitel_dect.py
@@ -129,7 +129,7 @@ class MitelDECT(PhoneFlavor):
                         extension=tmp_ext_id,
                         extension_name="DECT TMP",
                         password=password,
-                        codec=self.get_codec(),
+                        codec=self.get_codec(None),
                         context="pjsip_dect_tmp",
                     )
 

--- a/app/telephoning/phonetypes/sip.py
+++ b/app/telephoning/phonetypes/sip.py
@@ -5,10 +5,26 @@ Copyright (c) Ole Lange, Gregor Michels and contributors. All rights reserved.
 Licensed under the MIT license. See LICENSE file in the project root for details.
 """
 
-from app.telephoning.flavor import PhoneFlavor
+from pydantic import BaseModel
+from app.telephoning.flavor import CODEC, PhoneFlavor
+
+
+class SIPFields(BaseModel):
+    codec: CODEC = "g722"
 
 
 class SIP(PhoneFlavor):
     PHONE_TYPES = ["SIP"]
     DISPLAY_INDEX = 1000
     IS_SPECIAL = False
+    EXTRA_FIELDS = SIPFields
+
+    def get_codec(self, extension) -> CODEC:
+        if extension is None:
+            return super().get_codec(extension)
+
+        codec = extension.get_extra_field("codec")
+        if codec is not None:
+            return codec
+
+        return "g722"


### PR DESCRIPTION
The `create_asterisk_extension` CRUD method now asks the selected `PhoneFlavor` class which codec should be used for the extension. The `get_codec` method is implemented so that it resembles the old way using the SUPPORTED_CODEC str/dict attribute of a PhoneFlavor. If a PhoneFlavor want's to implement a more dynamic way to set the CODEC (e.G. based on an extra field) it can inherit the `get_codec` method.

### Todo:
Currently only the `create_asterisk_extension` checks the `get_codec` method. If an extension is updated, the codec is not updated yet.