### PR TITLE
SMALL: Fix/extension length limit

### DIFF
--- a/app/api/telephoning.py
+++ b/app/api/telephoning.py
@@ -21,6 +21,7 @@ class PhoneType(BaseModel):
     schema: Optional[dict] = None
     display_index: int
     name: str
+    max_extension_name_chars: int
 
 
 @router.get("/types")
@@ -33,6 +34,7 @@ def get_phone_types(user: CurrentUser) -> list[PhoneType]:
                     schema=flavor.get_schema(),
                     display_index=flavor.DISPLAY_INDEX,
                     name=phone_type,
+                    max_extension_name_chars=flavor.MAX_EXTENSION_NAME_CHARS,
                 )
                 schemas.append(pt)
     return schemas

--- a/app/models/crud/extension.py
+++ b/app/models/crud/extension.py
@@ -119,6 +119,9 @@ def create_extension(
             )
 
     try:
+        if len(extension.name) > flavor.MAX_EXTENSION_NAME_CHARS:
+            raise CRUDNotAllowedException("Extension name too long!")
+
         db_obj = Extension.model_validate(
             extension,
             update={
@@ -198,6 +201,10 @@ def update_extension(
 
         data = update_data.model_dump(exclude_unset=True)
         extension.sqlmodel_update(data)
+
+        if len(extension.name) > flavor.MAX_EXTENSION_NAME_CHARS:
+            raise CRUDNotAllowedException("Extension name too long!")
+
         session.add(extension)
 
         if not flavor.PREVENT_SIP_CREATION:

--- a/app/telephoning/flavor.py
+++ b/app/telephoning/flavor.py
@@ -77,6 +77,9 @@ class PhoneFlavor:
     # account is created in the asterisk database
     PREVENT_SIP_CREATION = False
 
+    # This limits the maximum amount of characters for the extension name
+    MAX_EXTENSION_NAME_CHARS = 20
+
     def on_extension_create(
         self,
         session: Session,

--- a/frontend/src/client/types.gen.ts
+++ b/frontend/src/client/types.gen.ts
@@ -230,6 +230,10 @@ export type PhoneType = {
      * Name
      */
     name: string;
+    /**
+     * Max Extension Name Chars
+     */
+    max_extension_name_chars: number;
 };
 
 /**

--- a/frontend/src/routes/extension_edit.svelte
+++ b/frontend/src/routes/extension_edit.svelte
@@ -263,7 +263,12 @@
 	</FormGroup>
 	<FormGroup>
 		<Label>Name *</Label>
-		<Input bind:value={nameInput} placeholder="{user_info.val?.username}'s extension" required />
+		<Input
+			bind:value={nameInput}
+			placeholder="{user_info.val?.username}'s extension"
+			maxlength={selectedType?.max_extension_name_chars}
+			required
+		/>
 	</FormGroup>
 	<FormGroup>
 		<Label>Info</Label>


### PR DESCRIPTION
Adds an `MAX_EXTENSION_NAME_CHARS` attribute to the phone flavor class which sets the character limit for extension names. It defaults to 20 because that is the limitation of mitel omm and it seems reasonable for me to limit all extensions to this. Maybe this might be something which should be configurable in future